### PR TITLE
[NU-2364] Fix for: bootstrapper was restarting because of postgres / wiremock unavailability

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,8 +1,8 @@
 #!/bin/bash -e
 
-/app/setup/is-setup-done.sh \
-  && /app/mocks/db/is-postgres-ready.sh \
-  && /app/mocks/http-service/is-wiremock-ready.sh \
-  || exit 1
+/app/setup/is-setup-done.sh && \
+  ([ ! -f /app/.status/mocks-used ] || \
+    (/app/mocks/db/is-postgres-ready.sh && \
+     /app/mocks/http-service/is-wiremock-ready.sh)) || exit 1
 
 exit 0

--- a/scenario-examples-bootstrapper/mocks/db/is-postgres-ready.sh
+++ b/scenario-examples-bootstrapper/mocks/db/is-postgres-ready.sh
@@ -1,5 +1,3 @@
 #!/bin/bash -e
 
-if [ -f /app/.status/mocks-used ]; then
-  pg_isready -d mocks -U mocks > /dev/null
-fi
+pg_isready -d mocks -U mocks > /dev/null

--- a/scenario-examples-bootstrapper/mocks/http-service/is-wiremock-ready.sh
+++ b/scenario-examples-bootstrapper/mocks/http-service/is-wiremock-ready.sh
@@ -1,5 +1,3 @@
 #!/bin/bash -e
 
-if [ -f /app/.status/mocks-used ]; then
-  curl -f -s http://localhost:8080/__admin/ > /dev/null
-fi
+curl -f -s http://localhost:8080/__admin/health > /dev/null

--- a/scenario-examples-bootstrapper/run-mocks-setup-data.sh
+++ b/scenario-examples-bootstrapper/run-mocks-setup-data.sh
@@ -3,16 +3,18 @@
 cd "$(dirname "$0")"
 
 source /app/utils/lib.sh
-configure_error_handling
 
 rm -rf /app/.status
 mkdir -p /app/.status
 
-/app/utils/configure-clients.sh
-
 if /app/mocks/db/is-postgres-ready.sh && /app/mocks/http-service/is-wiremock-ready.sh; then
+  # We configure error trap after we check that Postgres and Wiremock is ready.
+  # Unavailability of these services is a normal situation because phusion/baseimage doesn't handle
+  # dependencies checking/service startup ordering
+  configure_error_handling
   green_echo "------ Nu scenarios library is being prepared... ---------\n"
-  
+  /app/utils/configure-clients.sh
+
   if are_embedded_examples_active; then 
     mkdir -p /scenario-examples
     if [ "$(ls -A /tmp/scenario-examples)" ]; then


### PR DESCRIPTION
In our main script (`run-mocks-setup-data.sh`), we have a check that should postpone the boostrapping logic until all dependent services are available. The check is a good approach because the Docker image that we are using under the hood (`phusion/baseimage`) doesn't support service dependencies/start ordering.

The problem was that this check didn't work. In #9 we added `[ -f /app/.status/mocks-used ]` condition in both readiness scripts. I suppose that it was done because of `healthcheck.sh` optimisation, where these scripts are also invoked. The `/app/.status/mocks-used` file appears after all boostrapping logic is done, so checking it before bootstrapping logic makes no sense.